### PR TITLE
iso-remaster: use createrepo_c in sample script

### DIFF
--- a/scripts/iso-remaster/samples/patch-iso.sh
+++ b/scripts/iso-remaster/samples/patch-iso.sh
@@ -42,7 +42,7 @@ ISODIR="$1"
 
 
 ## regenerate repodata
-#createrepo "$ISODIR"
+#createrepo_c "$ISODIR"
 
 ## patches to kernel commandline
 SED_COMMANDS=()


### PR DESCRIPTION
Plain `createrepo` is not available in Debian, using `createrepo_c` makes things more portable.