### PR TITLE
Add libfaketime to the container for generating iso

### DIFF
--- a/scripts/gen-iso.sh
+++ b/scripts/gen-iso.sh
@@ -46,7 +46,7 @@ else
     MNTVOL="XCP-NG"
 fi
 
-sudo yum install -y genisoimage syslinux grub-tools createrepo_c
+sudo yum install -y genisoimage syslinux grub-tools createrepo_c libfaketime
 
 cd /data
 


### PR DESCRIPTION
I run tests on 8.2 and 8.3 on Jenkins. The generation runs fine.