### PR TITLE
Change the name of the Volume ID in the iso generated

### DIFF
--- a/scripts/gen-iso.sh
+++ b/scripts/gen-iso.sh
@@ -38,13 +38,7 @@ NAMEIMG="install-${VERSION}-${REPOSITORY}.img"
 NAMEISO="xcp-ng-${VERSION}-${REPOSITORY}-nightly-${THEDATE}.iso"
 NAMEISONI="xcp-ng-${VERSION}-${REPOSITORY}-netinstall-nightly-${THEDATE}.iso"
 
-if [ "$VERSION" = "8.3" ]; then
-    MNTVOL="XCP-NG_83"
-elif [ "$VERSION" = "8.2" ]; then
-    MNTVOL="XCP-NG_82"
-else
-    MNTVOL="XCP-NG"
-fi
+MNTVOL="XCP-ng ${VERSION} ${REPOSITORY} ${THEDATE}"
 
 sudo yum install -y genisoimage syslinux grub-tools createrepo_c libfaketime
 


### PR DESCRIPTION
To have a more explicit name for the Volume ID, we've changed the parameter to have a name like:
"XCP-ng version repository date"
Example: XCP-ng 8.3 updates 20230621