### PR TITLE
Modify script gen-iso.sh for PR21

### DIFF
--- a/scripts/gen-iso.sh
+++ b/scripts/gen-iso.sh
@@ -46,6 +46,6 @@ cd /data
 
 sudo ./scripts/create-installimg.sh --srcurl "https://updates.xcp-ng.org/8/${VERSION}" -o "${NAMEIMG}" "${VERSION}":"${REPOSITORY}"
 
-./scripts/create-install-iso.sh --netinstall --srcurl "https://updates.xcp-ng.org/8/${VERSION}" -V "${MNTVOL}" -o "${NAMEISONI}" "${VERSION}":"${REPOSITORY}" "${NAMEIMG}"
+./scripts/create-iso.sh --netinstall --srcurl "https://updates.xcp-ng.org/8/${VERSION}" -V "${MNTVOL}" -o "${NAMEISONI}" "${VERSION}":"${REPOSITORY}" "${NAMEIMG}"
 
-./scripts/create-install-iso.sh --srcurl "https://updates.xcp-ng.org/8/${VERSION}" -V "${MNTVOL}" -o "${NAMEISO}" "${VERSION}":"${REPOSITORY}" "${NAMEIMG}"
+./scripts/create-iso.sh --srcurl "https://updates.xcp-ng.org/8/${VERSION}" -V "${MNTVOL}" -o "${NAMEISO}" "${VERSION}":"${REPOSITORY}" "${NAMEIMG}"


### PR DESCRIPTION
Modification on the script gen-iso.sh to take into account the renaming of the file create-install-iso.sh into  scripts/create-iso.sh

We need to merge this at the same time or Jenkins won't be able to generate iso.