### PR TITLE
create_rpm_git_repo.py: Fix initial commit message

### DIFF
--- a/scripts/create_rpm_git_repo.py
+++ b/scripts/create_rpm_git_repo.py
@@ -56,7 +56,7 @@ Built RPMs and source RPMs are available on https://updates.xcp-ng.org.
     subprocess.check_call(['git', 'lfs', 'track', '*.tgz'])
     subprocess.check_call(['git', 'lfs', 'track', '*.tbz'])
     subprocess.check_call(['git', 'add', '.gitattributes'])
-    subprocess.check_call(['git', 'commit', '-s', '-m Initial commit'])
+    subprocess.check_call(['git', 'commit', '-s', '-m', 'Initial commit'])
     subprocess.check_call(['git', 'push'])
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch removes an extra space character that was inserted in front of the initial commit message.