### PR TITLE
Open file in text mode

### DIFF
--- a/scripts/download_centos.py
+++ b/scripts/download_centos.py
@@ -73,7 +73,7 @@ def main():
         local_epel=os.path.abspath(args.local_epel)
 
     srpms_to_rpms = {}
-    with open(args.centos_rpms_and_srpms, 'rb') as csvfile:
+    with open(args.centos_rpms_and_srpms, 'r') as csvfile:
         for row in csv.reader(csvfile, delimiter=','):
             if row[1] not in srpms_to_rpms:
                 srpms_to_rpms[row[1]] = []


### PR DESCRIPTION
If we open the file using bytes it generates the following error: _csv.Error: iterator should return strings, not bytes (the file should be opened in text mode)