### PR TITLE
Fix alternate upgrade method of XCP-ng

### DIFF
--- a/iso/8.3/.treeinfo
+++ b/iso/8.3/.treeinfo
@@ -1,3 +1,11 @@
+[platform]
+name = XCP
+version = 3.4.0
+
+[branding]
+name = XCP-ng
+version = 8.3.0
+
 [system-v1]
 platform_name = XCP
 platform_version = 3.3.0


### PR DESCRIPTION
The plugin `prepare_host_upgrade.py` looks for the added entries in the `.treeinfo` in order to do the upgrade.