### PR TITLE
import_srpm: do not pull if we do not push

### DIFF
--- a/scripts/import_srpm.py
+++ b/scripts/import_srpm.py
@@ -42,7 +42,8 @@ def main():
 
     subprocess.check_call(['git', 'fetch'])
     subprocess.check_call(['git', 'checkout', args.parent_branch])
-    subprocess.check_call(['git', 'pull'])
+    if args.push:
+        subprocess.check_call(['git', 'pull'])
 
     print(" removing everything from SOURCES and SPECS...")
 


### PR DESCRIPTION
Makes the script fully-local by default, providing a way to import on local branches before we know if we want to published them.