### PR TITLE
add `--test-build` flag to `koji_build`

### DIFF
--- a/scripts/koji/koji_build.py
+++ b/scripts/koji/koji_build.py
@@ -112,6 +112,8 @@ def main():
         urls = []
         for d in git_repos:
             remote, hash = get_repo_and_commit_info(d)
+            if test_build:
+                hash = push_bumped_release(d, test_build)
             urls.append(koji_url(remote, hash))
         command = ['koji', 'chain-build', target] + (' : '.join(urls)).split(' ') +  (['--nowait'] if is_nowait else [])
         print('  '.join(command), flush=True)

--- a/scripts/koji/koji_build.py
+++ b/scripts/koji/koji_build.py
@@ -73,7 +73,7 @@ def main():
         remote, hash = get_repo_and_commit_info(git_repos[0])
         url = koji_url(remote, hash)
         command = ['koji', 'build'] + (['--scratch'] if is_scratch else []) + [target, url] + (['--nowait'] if is_nowait else [])
-        subprocess.check_call(['echo'] + command)
+        print('  '.join(command), flush=True)
         subprocess.check_call(command)
     else:
         urls = []
@@ -81,7 +81,7 @@ def main():
             remote, hash = get_repo_and_commit_info(d)
             urls.append(koji_url(remote, hash))
         command = ['koji', 'chain-build', target] + (' : '.join(urls)).split(' ') +  (['--nowait'] if is_nowait else [])
-        subprocess.check_call(['echo'] + command)
+        print('  '.join(command), flush=True)
         subprocess.check_call(command)
 
 if __name__ == "__main__":

--- a/scripts/koji/koji_build.py
+++ b/scripts/koji/koji_build.py
@@ -77,7 +77,22 @@ def clean_old_branches(git_repo):
             print("removing outdated remote branch(es)", flush=True)
             subprocess.check_call(['git', 'push', '--delete', 'origin'] + old_branches)
 
-def push_bumped_release(git_repo, test_build_id):
+def xcpng_version(target):
+    xcpng_version_match = re.match(r'^v(\d+\.\d+)-u-\S+$', target)
+    if xcpng_version_match is None:
+        raise Exception(f"Can't find XCP-ng version in {target}")
+    return xcpng_version_match.group(1)
+    
+def find_next_build_number(package, spec, target, test_build_id):
+    builds = subprocess.check_output(['koji', 'list-builds', '--quiet', '--package', package]).decode().splitlines()
+    base_nvr = f'{package}-{spec.version}-{spec.release}.0.{test_build_id}.'
+    # use a regex to match %{macro} without actually expanding the macros
+    base_nvr_re = re.escape(re.sub('%{.+}', "@@@", base_nvr)).replace('@@@', '.*') + r'(\d+)' + re.escape(f'.xcpng{xcpng_version(target)}')
+    build_matches = [re.match(base_nvr_re, b) for b in builds]
+    build_nbs = [int(m.group(1)) for m in build_matches if m]
+    return sorted(build_nbs)[-1] + 1 if build_nbs else 1
+    
+def push_bumped_release(git_repo, target, test_build_id):
     t = datetime.now().strftime(TIME_FORMAT)
     branch = f'koji/test/{test_build_id}/{t}'
     with cd(git_repo), local_branch(branch):
@@ -87,14 +102,8 @@ def push_bumped_release(git_repo, test_build_id):
         with Specfile(spec_path) as spec:
             # find the next build number
             package = Path(spec_path).stem
-            builds = subprocess.check_output(['koji', 'list-builds', '--package', package]).decode().splitlines()[2:]
-            base_nvr = f'{package}-{spec.version}-{spec.release}.0.{test_build_id}.'
-            # use a regex to match %{macro} without actually expanding the macros
-            base_nvr_re = re.escape(re.sub('%{.+}', "@@@", base_nvr)).replace('@@@', '.*') + r'(\d+)'
-            build_matches = [re.match(base_nvr_re, b) for b in builds]
-            build_ids = [int(m.group(1)) for m in build_matches if m]
-            next_build_id = sorted(build_ids)[-1] + 1 if build_ids else 1
-            spec.release = f'{spec.release}.0.{test_build_id}.{next_build_id}'
+            next_build_nb = find_next_build_number(package, spec, target, test_build_id)
+            spec.release = f'{spec.release}.0.{test_build_id}.{next_build_nb}'
         subprocess.check_call(['git', 'commit', '--quiet', '-m', "bump release for test build", spec_path])
         subprocess.check_call(['git', 'push', 'origin', f'HEAD:refs/heads/{branch}'])
         commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode().strip()
@@ -131,7 +140,7 @@ def main():
         clean_old_branches(git_repos[0])
         remote, hash = get_repo_and_commit_info(git_repos[0])
         if test_build:
-            hash = push_bumped_release(git_repos[0], test_build)
+            hash = push_bumped_release(git_repos[0], target, test_build)
         url = koji_url(remote, hash)
         command = ['koji', 'build'] + (['--scratch'] if is_scratch else []) + [target, url] + (['--nowait'] if is_nowait else [])
         print('  '.join(command), flush=True)
@@ -142,7 +151,7 @@ def main():
             clean_old_branches(d)
             remote, hash = get_repo_and_commit_info(d)
             if test_build:
-                hash = push_bumped_release(d, test_build)
+                hash = push_bumped_release(d, target, test_build)
             urls.append(koji_url(remote, hash))
         command = ['koji', 'chain-build', target] + (' : '.join(urls)).split(' ') +  (['--nowait'] if is_nowait else [])
         print('  '.join(command), flush=True)

--- a/scripts/koji/koji_build.py
+++ b/scripts/koji/koji_build.py
@@ -4,6 +4,9 @@ import os
 import subprocess
 import re
 from contextlib import contextmanager
+from uuid import uuid4
+
+from specfile import Specfile
 
 
 @contextmanager
@@ -47,6 +50,32 @@ def koji_url(remote, hash):
         raise Exception("Unrecognized remote URL")
     return remote + "?#" + hash
 
+@contextmanager
+def local_branch(branch):
+    prev_branch = subprocess.check_output(['git', 'branch', '--show-current']).strip()
+    subprocess.check_call(['git', 'checkout', '-b', branch])
+    try:
+        yield branch
+    finally:
+        subprocess.check_call(['git', 'checkout', prev_branch])
+        subprocess.check_call(['git', 'branch', '-D', branch])
+        subprocess.check_call(['git', 'push', '--delete', 'origin', branch])
+
+def push_bumped_release(git_repo, test_build_id):
+    uuid = uuid4()
+    branch = f'koji/test/{uuid}'
+    with cd(git_repo), local_branch(branch):
+        spec_paths = subprocess.check_output(['git', 'ls-files', 'SPECS/*.spec']).decode().splitlines()
+        assert len(spec_paths) == 1
+        spec_path = spec_paths[0]
+        with Specfile(spec_path) as spec:
+            # TODO: check koji build to use another final number when needed
+            spec.release = f'{spec.release}.0.{test_build_id}.1'
+        subprocess.check_call(['git', 'commit', '-m', "bump release for test build", spec_path])
+        subprocess.check_call(['git', 'push', 'origin', branch])
+        commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode().strip()
+        return commit
+
 def main():
     parser = argparse.ArgumentParser(description='Build a package or chain-build several from local git repos for RPM sources')
     parser.add_argument('target', help='Koji target for the build')
@@ -55,12 +84,14 @@ def main():
                              'a chained build will be started in the order of the arguments')
     parser.add_argument('--scratch', action="store_true", help='Perform scratch build')
     parser.add_argument('--nowait', action="store_true", help='Do not wait for the build to end')
+    parser.add_argument('--test-build', metavar="ID", help='Run a test build. The provided ID will be used to build a unique release tag.')
     args = parser.parse_args()
 
     target = args.target
     git_repos = [os.path.abspath(check_dir(d)) for d in args.git_repos]
     is_scratch = args.scratch
     is_nowait = args.nowait
+    test_build = args.test_build
 
     if len(git_repos) > 1 and is_scratch:
         parser.error("--scratch is not compatible with chained builds.")
@@ -71,6 +102,8 @@ def main():
 
     if len(git_repos) == 1:
         remote, hash = get_repo_and_commit_info(git_repos[0])
+        if test_build:
+            hash = push_bumped_release(git_repos[0], test_build)
         url = koji_url(remote, hash)
         command = ['koji', 'build'] + (['--scratch'] if is_scratch else []) + [target, url] + (['--nowait'] if is_nowait else [])
         print('  '.join(command), flush=True)

--- a/scripts/koji/koji_build.py
+++ b/scripts/koji/koji_build.py
@@ -8,7 +8,11 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from specfile import Specfile
+try:
+    from specfile import Specfile
+except ImportError:
+    print("error: specfile module can't be imported. Please install it with 'pip install --user specfile'.")
+    exit(1)
 
 TIME_FORMAT = '%Y-%m-%d-%H-%M-%S'
 

--- a/scripts/koji/koji_build.py
+++ b/scripts/koji/koji_build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import logging
 import os
 import subprocess
 import re
@@ -115,6 +116,9 @@ def main():
     is_scratch = args.scratch
     is_nowait = args.nowait
     test_build = args.test_build
+    if re.match('^[a-zA-Z0-9]{1,16}$', test_build) is None:
+        logging.error("The test build id must be 16 characters long maximum and only contain letters and digits")
+        exit(1)
 
     if len(git_repos) > 1 and is_scratch:
         parser.error("--scratch is not compatible with chained builds.")


### PR DESCRIPTION
When run with `koji_build.py --test-build gln --nowait v8.2-u-gln1 .`, it creates a new commit to bump the release and push it to github.
That way the release `2.5%{?dist}` becomes `2.5.0.gln.1%{dist}`.

The branch pushed to github is named `koji/test/<test build name>/<date>` (for example `koji/test/gln/2025-02-28-11-48-40`) and cleanup when it is more than 3 hours old the next time someone uses koji_build on that repository.

Note that I've use an extra package — `specfile` that must be installed with `pip install --user specfile` before using the script.