### PR TITLE
pycodestyle, pydocstyle and ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.pydocstyle]
+ignore = "D100,D101,D102,D103,D104,D105,D106,D107,D203,D210,D212,D401,D403"
+
+
+[tool.ruff]
+preview = true
+line-length = 120
+
+[tool.ruff.format]
+quote-style = "preserve"
+
+[tool.ruff.lint]
+select = ["F", "I", "SLF", "SIM"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+# pycodestyle doesn't support pyproject.toml
+[pycodestyle]
+max-line-length=120
+ignore=E261,E302,E305,W503


### PR DESCRIPTION
`pycodestyle` and `pydocstyle` configuration from `xcp-ng-tests` repository, just moved to `pyproject.toml` when possible.

Some simple linter rules from ruff:

* https://docs.astral.sh/ruff/rules/#isort-i
* https://docs.astral.sh/ruff/rules/#pyflakes-f
* https://docs.astral.sh/ruff/rules/#flake8-self-slf
* https://docs.astral.sh/ruff/rules/#flake8-simplify-sim

This is just to help us during the dev. Most scripts in this repo would raise some errors, so no CI for now.