### PR TITLE
Add a script to terminate idle pg connections

### DIFF
--- a/scripts/terminate_idle_connections.py
+++ b/scripts/terminate_idle_connections.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import psycopg2
+
+IDLE_TIMEOUT_MINUTES = 10
+
+def main():
+    with psycopg2.connect(dbname="postgres") as conn, conn.cursor() as cur:
+        sql_query = f"""
+        SELECT pg_terminate_backend(pid)
+        FROM pg_stat_activity
+        WHERE
+            state = 'idle'
+            AND NOW() - state_change > INTERVAL '{IDLE_TIMEOUT_MINUTES} minutes'
+            AND pid <> pg_backend_pid();
+        """
+        cur.execute(sql_query)
+        num_terminated = len(cur.fetchall())
+    if num_terminated > 0:
+        print(f"terminated {num_terminated} connections")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Koji keeps opening new connections to the database, and keeps them open
up to the point where no new connection can be open. Koji then starts
to fail, with a database outage error message.

This scripts terminates the connexions older that 10 minutes, and is
intended to run every minute on the koji server.