### PR TITLE
koji_build.py: wait for the internal repo to be up to date

### DIFF
--- a/scripts/koji/koji_build.py
+++ b/scripts/koji/koji_build.py
@@ -229,7 +229,7 @@ def main():
             check_commit_is_available_remotely(git_repos[0], hash, None if is_scratch else target, args.force)
         url = koji_url(remote, hash)
         command = (
-            ['koji', 'build']
+            ['koji', 'build', '--wait-repo']
             + (['--scratch'] if is_scratch else [])
             + [target, url]
             + (['--nowait'] if is_nowait else [])


### PR DESCRIPTION
Add `--wait-repo` to `koji build` so that it starts the task with a waitrepo subtask which ensures that the internal repository for the build tag is up to date.