### PR TITLE
koji_build.py: fix XCP-ng release detection for test builds

### DIFF
--- a/scripts/koji/koji_build.py
+++ b/scripts/koji/koji_build.py
@@ -109,7 +109,7 @@ def clean_old_branches(git_repo):
             subprocess.check_call(['git', 'push', '--delete', 'origin'] + old_branches)
 
 def xcpng_version(target):
-    xcpng_version_match = re.match(r'^v(\d+\.\d+)-u-\S+$', target)
+    xcpng_version_match = re.match(r'^v(\d+\.\d+)-\S+$', target)
     if xcpng_version_match is None:
         raise Exception(f"Can't find XCP-ng version in {target}")
     return xcpng_version_match.group(1)


### PR DESCRIPTION
The current code assumes we're in a vX.Y-u- tag, but we can also do test builds in v8.3-lab.