### PR TITLE
RPM owners: transfer guest-templates-json to H&K team

### DIFF
--- a/scripts/rpm_owners/packages.json
+++ b/scripts/rpm_owners/packages.json
@@ -1280,7 +1280,7 @@
     },
     "guest-templates-json": {
         "added_by": "XS",
-        "maintainer": "XAPI & Network",
+        "maintainer": "Hypervisor & Kernel",
         "package": "guest-templates-json",
         "status": "packaged"
     },


### PR DESCRIPTION
It would make sense to let the "Guests team" handle the default VM templates, more than the XAPI team.