### PR TITLE
github: Add json lint check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+# YAML -*- mode: yaml; tab-width: 2; indent-tabs-mode: nil; coding: utf-8 -*-
+---
+name: check
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: checkout
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: check
+        run: make check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+#!/usr/bin/make -f
+# -*- makefile -*-
+# ex: set tabstop=4 noexpandtab:
+# -*- coding: utf-8 -*
+
+default: help
+
+jq?=jq --indent 4
+
+help: README.md
+	@echo "Please read $^"
+	@echo ""
+	@head $^
+	@echo ""
+	@echo "More details in $^"
+
+setup:
+	@echo "info: $@: Checking presence of tools if not please install them"
+	${jq} --version
+
+lint: setup
+	@echo "info: $@: json files"
+	find . \
+		-iname "*_cache" -type d -prune -false \
+		-o -iname "*.json" -type f \
+		-print \
+	| while read file ; do \
+		${jq} . "$${file}" > "$${file}.tmp" && mv "$${file}.tmp" "$${file}" ; \
+	done
+
+check: lint
+	@echo "info: $@: will pass if sources are linted, if not please lint and commit"
+	git diff --stat --exit-code


### PR DESCRIPTION
## Motivation

This will prevent future breaks (like the previous one that @glehmann fixed),
more check to be introduced (on yaml files etc)


## Demo:

Failed check:

https://github.com/xcp-ng/xcp/actions/runs/24389050719/job/71229969217

```
info: check: will pass if sources are linted, if not please lint and commit
git diff --stat --exit-code
 scripts/rpm_owners/packages.json | 10244 ++++++++++++++++++-------------------
 1 file changed, 5122 insertions(+), 5122 deletions(-)
make: *** [Makefile:31: check] Error 1
```

Failed successful:

https://github.com/rzr/xcp/actions/runs/24389156947/job/71230340848# 

```
5 info: check: will pass if sources are linted, if not please lint and commit 
git diff --stat --exit-code
```
