### PR TITLE
scripts/snapshot-fixer: Bring xapi back up if it was stopped before running the script

### DIFF
--- a/scripts/snapshot-fixer.py
+++ b/scripts/snapshot-fixer.py
@@ -88,11 +88,19 @@ def start_ha():
 
 def query_and_stop_ha():
     logging.info('Check HA...')
-    r = subprocess.run(
-        [ 'xe', 'pool-list', '--minimal' ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    )
+    def pool_list():
+        return subprocess.run(
+            [ 'xe', 'pool-list', '--minimal' ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+    r = pool_list()
+    if r.returncode != 0:
+        logging.info('Xapi was down, bringing it up to check HA')
+        start_xapi(False)
+    while r.returncode != 0:
+        r = pool_list()
+        time.sleep(0.1)
     pool_uuid = r.stdout.strip().split()[-1].decode('utf-8')
     r = subprocess.run(
         [ 'xe', 'pool-param-get', 'param-name=ha-enabled', 'uuid=' + pool_uuid ],


### PR DESCRIPTION
If xapi was manually stopped before running the script, then it would fail:

    $ python3 snapshot-fixer.py rewrite
    INFO:root:Check HA...
    Traceback (most recent call last):
      File "snapshot-fixer.py", line 237, in <module>
        main()
      File "snapshot-fixer.py", line 234, in main
        args.func(args)
      File "snapshot-fixer.py", line 177, in rewrite
        ha_enabled = query_and_stop_ha()
      File "snapshot-fixer.py", line 96, in query_and_stop_ha
        pool_uuid = r.stdout.strip().split()[-1].decode('utf-8')
    IndexError: list index out of range

Handle this failure and start xapi back up to check HA instead:

    $ python3 snapshot-fixer.py rewrite
    INFO:root:Check HA...
    INFO:root:Xapi was down, bringing it up to check HA
    INFO:root:Starting up xapi...
    INFO:root:Shutting down xapi...
    INFO:root:Regenerating database...
    INFO:root:Writing database to /var/lib/xcp/state.db
    INFO:root:Starting up xapi...