### PR TITLE
packages.json: Add libidn2

### DIFF
--- a/scripts/rpm_owners/packages.json
+++ b/scripts/rpm_owners/packages.json
@@ -1958,6 +1958,12 @@
         "package": "libdwarf",
         "status": "packaged"
     },
+    "libidn2": {
+        "added_by": "XS",
+        "maintainer": "OS Platform & Release",
+        "package": "libidn2",
+        "status": "packaged"
+    },
     "libedit": {
         "added_by": "XS",
         "maintainer": "OS Platform & Release",


### PR DESCRIPTION
This is a new build-dependency of gnutls

Related-to: XCPNG-2698
Related-to: https://github.com/xcp-ng-rpms/libidn2/pull/1