### PR TITLE
Add the xcp-efivar-utils package

### DIFF
--- a/scripts/rpm_owners/packages.json
+++ b/scripts/rpm_owners/packages.json
@@ -4766,6 +4766,12 @@
         "package": "xcp-clipboardd",
         "status": "packaged"
     },
+    "xcp-efivar-utils": {
+        "added_by": "XCP-ng",
+        "maintainer": "Hypervisor & Kernel",
+        "package": "xcp-efivar-utils",
+        "status": "packaged"
+    },
     "xcp-emu-manager": {
         "added_by": "XCP-ng",
         "maintainer": "Hypervisor & Kernel",


### PR DESCRIPTION
This package contains an assortment of useful Python functions for manipulating UEFI variables on XCP-ng pools and VMs.