### PR TITLE
RPM owners: Add qlogic-fastlinq-alt_8.42 package

### DIFF
--- a/scripts/rpm_owners/packages.json
+++ b/scripts/rpm_owners/packages.json
@@ -4029,6 +4029,13 @@
         "package": "qlogic-fastlinq-alt",
         "status": "packaged"
     },
+    "qlogic-fastlinq-alt_8.42": {
+        "added_by": "XCP-ng",
+        "maintainer": "Hypervisor & Kernel",
+        "note": "additional driver",
+        "package": "qlogic-fastlinq-alt_8.42",
+        "status": "packaged"
+    },
     "qlogic-netxtreme2": {
         "added_by": "XS",
         "maintainer": "Hypervisor & Kernel",


### PR DESCRIPTION
This package provides an older version of the qlogic-fastlinq driver than the ones in the main and alt package. This older version 8.42.10.0 is know to work with some old hardware not well supported by newer versions of the driver.