### PR TITLE
RPM owners: Rename package qlogic-fastlinq-alt_8_42

### DIFF
--- a/scripts/rpm_owners/packages.json
+++ b/scripts/rpm_owners/packages.json
@@ -4029,11 +4029,11 @@
         "package": "qlogic-fastlinq-alt",
         "status": "packaged"
     },
-    "qlogic-fastlinq-alt_8.42": {
+    "qlogic-fastlinq-alt_8_42": {
         "added_by": "XCP-ng",
         "maintainer": "Hypervisor & Kernel",
         "note": "additional driver",
-        "package": "qlogic-fastlinq-alt_8.42",
+        "package": "qlogic-fastlinq-alt_8_42",
         "status": "packaged"
     },
     "qlogic-netxtreme2": {


### PR DESCRIPTION
The disk creation tool does not support the '.' character in package name so rename it from 'qlogic-fastlinq-alt_8.42' to 'qlogic-fastlinq-alt_8_42'.