### PR TITLE
Add koji-helper.py: a Python script to list source packages from a Koji tag and updates

### DIFF
--- a/scripts/koji/koji-helper.py
+++ b/scripts/koji/koji-helper.py
@@ -52,6 +52,8 @@ def list_source_packages(session, tag, latest=False):
 
     Returns a dict mapping package name to its info:
         - nvr: name-version-release string
+        - version: package version
+        - release: package release
     """
     # Get the tag info
     tag_info = session.getTag(tag, strict=True)
@@ -64,7 +66,9 @@ def list_source_packages(session, tag, latest=False):
         name = build["package_name"]
         if name not in results:
             results[name] = {
-                "nvr": build["nvr"]
+                "nvr": build["nvr"],
+                "version": build["version"],
+                "release": build["release"],
             }
 
     return tag_info, results
@@ -79,7 +83,11 @@ def list_update_source_packages(session, to_tag, from_tag=None, latest=False):
 
     Returns a dict mapping package name to its info:
         - nvr: name-version-release string in to_tag
+        - version: package version in to_tag
+        - release: package release in to_tag
         - base_nvr: name-version-release string in from_tag (if provided)
+        - base_version: package version in from_tag
+        - base_release: package release in from_tag
     """
     to_tag_info, to_packages = list_source_packages(session, to_tag, latest=latest)
 
@@ -91,11 +99,19 @@ def list_update_source_packages(session, to_tag, from_tag=None, latest=False):
     for name, info in to_packages.items():
         to_nvr = info["nvr"]
         if from_tag:
-            base_nvr = base_packages.get(name, {}).get("nvr")
+            base_info = base_packages.get(name, {})
+            base_nvr = base_info.get("nvr")
             if base_nvr and base_nvr != to_nvr:
-                results[name] = {"nvr": to_nvr, "base_nvr": base_nvr}
+                results[name] = {
+                    "nvr": to_nvr,
+                    "version": info["version"],
+                    "release": info["release"],
+                    "base_nvr": base_nvr,
+                    "base_version": base_info.get("version"),
+                    "base_release": base_info.get("release"),
+                }
         else:
-            results[name] = {"nvr": to_nvr}
+            results[name] = {"nvr": to_nvr, "version": info["version"], "release": info["release"]}
 
     return to_tag_info, results
 
@@ -142,7 +158,9 @@ def do_list_update(session, opts):
     lines.append("-" * 60)
 
     for name, info in sorted(packages.items()):
-        lines.append(f"{name}: {info['base_nvr']} -> {info['nvr']}")
+        old_vr = f"{info.get('base_version')}-{info.get('base_release')}"
+        new_vr = f"{info['version']}-{info['release']}"
+        lines.append(f"{name}: {old_vr} -> {new_vr}")
 
     output_text = "\n".join(lines) + "\n"
 

--- a/scripts/koji/koji-helper.py
+++ b/scripts/koji/koji-helper.py
@@ -7,12 +7,15 @@
 List all source packages from a Koji tag.
 
 Usage:
-    uv run list_source_packages.py <tag> [OPTIONS]
+    uv run koji-helper.py list <tag> [OPTIONS]
+    uv run koji-helper.py update <to_tag> <from_tag> [OPTIONS]
 
 Examples:
-    uv run list_source_packages.py c9s
-    uv run list_source_packages.py f40 --latest
-    uv run list_source_packages.py epel9 --output packages.txt
+    uv run koji-helper.py list c9s
+    uv run koji-helper.py list f40 --latest
+    uv run koji-helper.py list epel9 --output packages.txt
+    uv run koji-helper.py update c9s f40
+    uv run koji-helper.py update c9s f40 --output updates.txt
 """
 
 # /// script
@@ -67,13 +70,93 @@ def list_source_packages(session, tag, latest=False):
     return tag_info, results
 
 
+def list_update_source_packages(session, to_tag, from_tag=None, latest=False):
+    """
+    List source packages that have been updated from from_tag to to_tag.
+
+    If from_tag is provided, returns packages where the NVR in to_tag
+    is different from the NVR in from_tag.
+
+    Returns a dict mapping package name to its info:
+        - nvr: name-version-release string in to_tag
+        - base_nvr: name-version-release string in from_tag (if provided)
+    """
+    to_tag_info, to_packages = list_source_packages(session, to_tag, latest=latest)
+
+    base_packages = {}
+    if from_tag:
+        _, base_packages = list_source_packages(session, from_tag, latest=latest)
+
+    results = {}
+    for name, info in to_packages.items():
+        to_nvr = info["nvr"]
+        if from_tag:
+            base_nvr = base_packages.get(name, {}).get("nvr")
+            if base_nvr and base_nvr != to_nvr:
+                results[name] = {"nvr": to_nvr, "base_nvr": base_nvr}
+        else:
+            results[name] = {"nvr": to_nvr}
+
+    return to_tag_info, results
+
+
+def do_list(session, opts):
+    tag_info, packages = list_source_packages(
+        session, opts.tag, latest=opts.latest
+    )
+
+    if not packages:
+        print(f"No source packages found in tag '{opts.tag}'.", file=sys.stderr)
+        sys.exit(0)
+
+    lines = []
+    lines.append(f"Tag: {tag_info['name']}")
+    lines.append(f"Total source packages: {len(packages)}")
+    lines.append("-" * 60)
+
+    for name, info in sorted(packages.items()):
+        lines.append(f"{info['nvr']}")
+
+    output_text = "\n".join(lines) + "\n"
+
+    if opts.output:
+        with open(opts.output, "w") as f:
+            f.write(output_text)
+        print(f"Output written to {opts.output}")
+    else:
+        print(output_text)
+
+
+def do_list_update(session, opts):
+    tag_info, packages = list_update_source_packages(
+        session, opts.tag, from_tag=opts.base_tag, latest=opts.latest
+    )
+
+    if not packages:
+        print(f"No updated source packages found.", file=sys.stderr)
+        sys.exit(0)
+
+    lines = []
+    lines.append(f"Updated packages from {opts.base_tag or 'any tag'} to {tag_info['name']}")
+    lines.append(f"Total updated source packages: {len(packages)}")
+    lines.append("-" * 60)
+
+    for name, info in sorted(packages.items()):
+        lines.append(f"{name}: {info['base_nvr']} -> {info['nvr']}")
+
+    output_text = "\n".join(lines) + "\n"
+
+    if opts.output:
+        with open(opts.output, "w") as f:
+            f.write(output_text)
+        print(f"Output written to {opts.output}")
+    else:
+        print(output_text)
+
+
 def main():
     parser = argparse.ArgumentParser(
-        description="List all source packages from a Koji tag."
-    )
-    parser.add_argument(
-        "tag",
-        help="The Koji tag to query (e.g., c9s, f40, epel9)",
+        description="Koji helper script."
     )
     parser.add_argument(
         "--server",
@@ -107,14 +190,31 @@ def main():
         help="Ignore SSL certificate verification errors",
     )
 
+    subparsers = parser.add_subparsers(dest="command")
+
+    # list command
+    list_parser = subparsers.add_parser("list", help="List all source packages from a tag")
+    list_parser.add_argument("tag", help="The Koji tag to query (e.g., c9s, f40, epel9)")
+
+    # list-update command
+    list_update_parser = subparsers.add_parser("list-update", help="List updated source packages between tags")
+    list_update_parser.add_argument("tag", help="The target Koji tag")
+    list_update_parser.add_argument("base_tag", help="The source Koji tag to compare against")
+
     global opts
     opts = parser.parse_args()
+
+    if not opts.command:
+        parser.print_help()
+        sys.exit(1)
+
     session = get_session(opts)
 
     try:
-        tag_info, packages = list_source_packages(
-            session, opts.tag, latest=opts.latest
-        )
+        if opts.command == "list":
+            do_list(session, opts)
+        elif opts.command == "list-update":
+            do_list_update(session, opts)
     except Exception as e:
         if opts.pdb:
             print(f"Error: {e}", file=sys.stderr)
@@ -122,28 +222,6 @@ def main():
         else:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
-
-    if not packages:
-        print(f"No source packages found in tag '{opts.tag}'.", file=sys.stderr)
-        sys.exit(0)
-
-    # Format output
-    lines = []
-    lines.append(f"Tag: {tag_info['name']}")
-    lines.append(f"Total source packages: {len(packages)}")
-    lines.append("-" * 60)
-
-    for name, info in sorted(packages.items()):
-        lines.append(f"{info['nvr']}")
-
-    output_text = "\n".join(lines) + "\n"
-
-    if opts.output:
-        with open(opts.output, "w") as f:
-            f.write(output_text)
-        print(f"Output written to {opts.output}")
-    else:
-        print(output_text)
 
 
 if __name__ == "__main__":

--- a/scripts/koji/koji-helper.py
+++ b/scripts/koji/koji-helper.py
@@ -8,14 +8,13 @@ List all source packages from a Koji tag.
 
 Usage:
     uv run koji-helper.py list <tag> [OPTIONS]
-    uv run koji-helper.py update <to_tag> <from_tag> [OPTIONS]
+    uv run koji-helper.py list-update <to_tag> <from_tag> [OPTIONS]
 
 Examples:
-    uv run koji-helper.py list c9s
-    uv run koji-helper.py list f40 --latest
-    uv run koji-helper.py list epel9 --output packages.txt
-    uv run koji-helper.py update c9s f40
-    uv run koji-helper.py update c9s f40 --output updates.txt
+    uv run koji-helper.py list v8.3-ci
+    uv run koji-helper.py list-update v8.3-ci v8.3-updates
+    uv run koji-helper.py --no-verify-ssl list-update v8.3-ci v8.3-updates
+
 """
 
 # /// script
@@ -26,7 +25,6 @@ Examples:
 # ///
 
 import argparse
-import pdb
 import sys
 
 import koji
@@ -34,11 +32,6 @@ import koji
 
 def get_session(opts):
     """Create and return a Koji client session."""
-    if opts.no_verify_ssl:
-        # Disable SSL verification warnings
-        import urllib3
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
     session = koji.ClientSession(
         opts.server,
         opts={"no_ssl_verify": opts.no_verify_ssl},
@@ -46,7 +39,7 @@ def get_session(opts):
     return session
 
 
-def list_source_packages(session, tag, latest=False):
+def list_source_packages(session, tag, latest=True):
     """
     List all source packages in the given tag.
 
@@ -74,7 +67,7 @@ def list_source_packages(session, tag, latest=False):
     return tag_info, results
 
 
-def list_update_source_packages(session, to_tag, from_tag=None, latest=False):
+def list_update_source_packages(session, to_tag, from_tag=None, latest=True):
     """
     List source packages that have been updated from from_tag to to_tag.
 
@@ -89,11 +82,11 @@ def list_update_source_packages(session, to_tag, from_tag=None, latest=False):
         - base_version: package version in from_tag
         - base_release: package release in from_tag
     """
-    to_tag_info, to_packages = list_source_packages(session, to_tag, latest=latest)
+    to_tag_info, to_packages = list_source_packages(session, to_tag)
 
     base_packages = {}
     if from_tag:
-        _, base_packages = list_source_packages(session, from_tag, latest=latest)
+        _, base_packages = list_source_packages(session, from_tag)
 
     results = {}
     for name, info in to_packages.items():
@@ -111,18 +104,23 @@ def list_update_source_packages(session, to_tag, from_tag=None, latest=False):
                     "base_release": base_info.get("release"),
                 }
         else:
-            results[name] = {"nvr": to_nvr, "version": info["version"], "release": info["release"]}
+            results[name] = {
+                "nvr": to_nvr,
+                "version": info["version"],
+                "release": info["release"]
+            }
 
     return to_tag_info, results
 
 
 def do_list(session, opts):
     tag_info, packages = list_source_packages(
-        session, opts.tag, latest=opts.latest
+        session, opts.tag
     )
 
     if not packages:
-        print(f"No source packages found in tag '{opts.tag}'.", file=sys.stderr)
+        print(f"No source packages found in tag '{opts.tag}'.",
+              file=sys.stderr)
         sys.exit(0)
 
     lines = []
@@ -135,25 +133,21 @@ def do_list(session, opts):
 
     output_text = "\n".join(lines) + "\n"
 
-    if opts.output:
-        with open(opts.output, "w") as f:
-            f.write(output_text)
-        print(f"Output written to {opts.output}")
-    else:
-        print(output_text)
+    print(output_text)
 
 
 def do_list_update(session, opts):
     tag_info, packages = list_update_source_packages(
-        session, opts.tag, from_tag=opts.base_tag, latest=opts.latest
+        session, opts.tag, from_tag=opts.base_tag
     )
 
     if not packages:
-        print(f"No updated source packages found.", file=sys.stderr)
+        print("No updated source packages found.", file=sys.stderr)
         sys.exit(0)
 
     lines = []
-    lines.append(f"Updated packages from {opts.base_tag or 'any tag'} to {tag_info['name']}")
+    lines.append("Updated packages from"
+                 f"{opts.base_tag or 'any tag'} to {tag_info['name']}")
     lines.append(f"Total updated source packages: {len(packages)}")
     lines.append("-" * 60)
 
@@ -164,12 +158,7 @@ def do_list_update(session, opts):
 
     output_text = "\n".join(lines) + "\n"
 
-    if opts.output:
-        with open(opts.output, "w") as f:
-            f.write(output_text)
-        print(f"Output written to {opts.output}")
-    else:
-        print(output_text)
+    print(output_text)
 
 
 def main():
@@ -182,27 +171,6 @@ def main():
         help="Koji hub server URL (default: %(default)s)",
     )
     parser.add_argument(
-        "--web-url",
-        default="https://koji.xcp-ng.org/",
-        help="Koji web UI URL (default: %(default)s)",
-    )
-    parser.add_argument(
-        "--latest",
-        action="store_true",
-        help="Only show the latest build per package",
-    )
-    parser.add_argument(
-        "--output",
-        "-o",
-        default=None,
-        help="Output file path (default: stdout)",
-    )
-    parser.add_argument(
-        "--pdb",
-        action="store_true",
-        help="Drop into pdb on error",
-    )
-    parser.add_argument(
         "--no-verify-ssl",
         action="store_true",
         help="Ignore SSL certificate verification errors",
@@ -211,13 +179,21 @@ def main():
     subparsers = parser.add_subparsers(dest="command")
 
     # list command
-    list_parser = subparsers.add_parser("list", help="List all source packages from a tag")
-    list_parser.add_argument("tag", help="The Koji tag to query (e.g., c9s, f40, epel9)")
+    list_parser = subparsers.add_parser(
+        "list",
+        help="List all source packages from a tag")
+    list_parser.add_argument(
+        "tag",
+        help="The Koji tag to query (e.g., c9s, f40, epel9)")
 
     # list-update command
-    list_update_parser = subparsers.add_parser("list-update", help="List updated source packages between tags")
+    list_update_parser = subparsers.add_parser(
+        "list-update",
+        help="List updated source packages between tags")
     list_update_parser.add_argument("tag", help="The target Koji tag")
-    list_update_parser.add_argument("base_tag", help="The source Koji tag to compare against")
+    list_update_parser.add_argument(
+        "base_tag",
+        help="The source Koji tag to compare against")
 
     global opts
     opts = parser.parse_args()
@@ -234,12 +210,8 @@ def main():
         elif opts.command == "list-update":
             do_list_update(session, opts)
     except Exception as e:
-        if opts.pdb:
-            print(f"Error: {e}", file=sys.stderr)
-            pdb.post_mortem()
-        else:
-            print(f"Error: {e}", file=sys.stderr)
-            sys.exit(1)
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/koji/koji-helper.py
+++ b/scripts/koji/koji-helper.py
@@ -29,27 +29,44 @@ Examples:
 
 import argparse
 import sys
+from typing import Any, NotRequired, TypedDict
 
 import koji
 
 
-def get_session(opts):
+class PackageInfo(TypedDict):
+    """Information about a source package build."""
+
+    nvr: str
+    version: str
+    release: str
+    base_version: NotRequired["PackageInfo | None"]
+
+
+Packages = dict[str, PackageInfo]
+
+
+def get_session(args: argparse.Namespace) -> koji.ClientSession:
     """Create and return a Koji client session."""
     session = koji.ClientSession(
-        opts.server,
-        opts={"no_ssl_verify": opts.no_verify_ssl},
+        args.server,
+        opts={"no_ssl_verify": args.no_verify_ssl},
     )
     return session
 
 
-def list_source_packages(session, tag, latest=True):
+def list_source_packages(
+    session: koji.ClientSession, tag: str, latest: bool = True
+) -> tuple[dict[str, Any], Packages]:
     """
     List all source packages in the given tag.
 
-    Returns a dict mapping package name to its info:
-        - nvr: name-version-release string
-        - version: package version
-        - release: package release
+    Returns a tuple of (tag_info, packages) where:
+        - tag_info: dict with tag metadata (name, id, etc.)
+        - packages: Packages type mapping package name to its info:
+            - nvr: name-version-release string
+            - version: package version
+            - release: package release
     """
     # Get the tag info
     tag_info = session.getTag(tag, strict=True)
@@ -57,7 +74,7 @@ def list_source_packages(session, tag, latest=True):
     # Get all source builds in the tag
     builds = session.listTagged(tag, latest=latest)
 
-    results = {}
+    results: Packages = {}
     for build in builds:
         name = build["package_name"]
         if name not in results:
@@ -70,66 +87,67 @@ def list_source_packages(session, tag, latest=True):
     return tag_info, results
 
 
-def list_update_source_packages(session, to_tag,
-                                from_tags=None, latest=True):
+def list_update_source_packages(
+    session: koji.ClientSession,
+    to_tag: str,
+    from_tags: list[str] | None = None,
+    latest: bool = True,
+) -> tuple[dict[str, Any], Packages]:
     """
     List source packages that have been updated from one or more
     from_tags to to_tag.
 
-    Returns a dict mapping package name to its info:
-        - nvr: name-version-release string in to_tag
-        - version: package version in to_tag
-        - release: package release in to_tag
-        - base_version: matching info from base tag or None
+    Returns a tuple of (tag_info, packages) where:
+        - tag_info: dict with tag metadata (name, id, etc.)
+        - packages: Packages type mapping package name to its info:
+            - nvr: name-version-release string in to_tag
+            - version: package version in to_tag
+            - release: package release in to_tag
+            - base_version: matching info from base tag or None
     """
+    if not from_tags:
+        msg = "At least one from_tag is required"
+        raise ValueError(msg)
+
     to_tag_info, to_packages = list_source_packages(session, to_tag)
 
-    base_packages = {}
-    if from_tags:
-        for from_tag in from_tags:
-            _, from_packages = list_source_packages(session, from_tag)
-            base_packages[from_tag] = from_packages
+    base_packages: dict[str, Packages] = {}
+    for from_tag in from_tags:
+        _, from_packages = list_source_packages(session, from_tag)
+        base_packages[from_tag] = from_packages
 
-    results = {}
+    results: Packages = {}
     for name, info in to_packages.items():
         to_nvr = info["nvr"]
-        if not from_tags:
-            results[name] = {
-                "nvr": to_nvr,
-                "version": info["version"],
-                "release": info["release"],
-                "base_version": None,
-            }
-        else:
-            base_version = None
-            for from_tag in from_tags:
-                from_pkgs = base_packages[from_tag]
-                if name in from_pkgs:
-                    base_info = from_pkgs[name]
-                    base_nvr = base_info.get("nvr")
-                    if base_nvr and base_nvr != to_nvr:
-                        base_version = base_info
-                        break
+        base_version: PackageInfo | None = None
+        for from_tag in from_tags:
+            from_pkgs = base_packages[from_tag]
+            if name in from_pkgs:
+                base_info = from_pkgs[name]
+                base_nvr = base_info.get("nvr")
+                if base_nvr and base_nvr != to_nvr:
+                    base_version = base_info
+                    break
 
-            results[name] = {
-                "nvr": to_nvr,
-                "version": info["version"],
-                "release": info["release"],
-                "base_version": base_version,
-            }
+        results[name] = {
+            "nvr": to_nvr,
+            "version": info["version"],
+            "release": info["release"],
+            "base_version": base_version,
+        }
 
     return to_tag_info, results
 
 
-def do_list(session, opts):
-    tag_info, packages = list_source_packages(
-        session, opts.tag
-    )
+def do_list(session: koji.ClientSession, args: argparse.Namespace) -> None:
+    tag_info, packages = list_source_packages(session, args.tag)
 
     if not packages:
-        print(f"No source packages found in tag '{opts.tag}'.",
-              file=sys.stderr)
-        sys.exit(0)
+        print(
+            f"No source packages found in tag '{args.tag}'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     lines = []
     lines.append(f"Tag: {tag_info['name']}")
@@ -144,19 +162,22 @@ def do_list(session, opts):
     print(output_text)
 
 
-def do_list_update(session, opts):
+def do_list_update(
+    session: koji.ClientSession, args: argparse.Namespace
+) -> None:
     tag_info, packages = list_update_source_packages(
-        session, opts.tag, from_tags=opts.base_tags
+        session, args.tag, from_tags=args.base_tags
     )
 
     if not packages:
         print("No updated source packages found.", file=sys.stderr)
-        sys.exit(0)
+        sys.exit(1)
 
     lines = []
-    base_tags_str = ', '.join(opts.base_tags) if opts.base_tags else 'any tag'
-    lines.append(f"Updated packages from {base_tags_str}"
-                 f" to {tag_info['name']}")
+    base_tags_str = ", ".join(args.base_tags) if args.base_tags else "any tag"
+    lines.append(
+        f"Updated packages from {base_tags_str} to {tag_info['name']}"
+    )
     lines.append(f"Total updated source packages: {len(packages)}")
     lines.append("-" * 60)
 
@@ -174,10 +195,8 @@ def do_list_update(session, opts):
     print(output_text)
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Koji helper script."
-    )
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Koji helper script.")
     parser.add_argument(
         "--server",
         default="https://kojihub.xcp-ng.org",
@@ -193,35 +212,32 @@ def main():
 
     # list command
     list_parser = subparsers.add_parser(
-        "list",
-        help="List all source packages from a tag")
-    list_parser.add_argument("tag",
-                             help="The Koji tag to query")
+        "list", help="List all source packages from a tag"
+    )
+    list_parser.add_argument("tag", help="The Koji tag to query")
 
     # list-update command
     list_update_parser = subparsers.add_parser(
-        "list-update",
-        help="List updated source packages between tags")
+        "list-update", help="List updated source packages between tags"
+    )
     list_update_parser.add_argument("tag", help="The target Koji tag")
     list_update_parser.add_argument(
-        "base_tags",
-        nargs="+",
-        help="The source Koji tags to compare against")
+        "base_tags", nargs="+", help="The source Koji tags to compare against"
+    )
 
-    global opts
-    opts = parser.parse_args()
+    args = parser.parse_args()
 
-    if not opts.command:
+    if not args.command:
         parser.print_help()
         sys.exit(1)
 
-    session = get_session(opts)
+    session = get_session(args)
 
     try:
-        if opts.command == "list":
-            do_list(session, opts)
-        elif opts.command == "list-update":
-            do_list_update(session, opts)
+        if args.command == "list":
+            do_list(session, args)
+        elif args.command == "list-update":
+            do_list_update(session, args)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/koji/koji-helper.py
+++ b/scripts/koji/koji-helper.py
@@ -8,12 +8,15 @@ List all source packages from a Koji tag.
 
 Usage:
     uv run koji-helper.py list <tag> [OPTIONS]
-    uv run koji-helper.py list-update <to_tag> <from_tag> [OPTIONS]
+    uv run koji-helper.py list-update \
+      <to_tag> <from_tag> [from_others_tags] [OPTIONS]
 
 Examples:
     uv run koji-helper.py list v8.3-ci
     uv run koji-helper.py list-update v8.3-ci v8.3-updates
-    uv run koji-helper.py --no-verify-ssl list-update v8.3-ci v8.3-updates
+    uv run koji-helper.py --no-verify-ssl list-update v8.3-ci \
+      v8.3-testing v8.3-candidates v8.3-updates v8.3-base
+
 
 """
 
@@ -67,47 +70,52 @@ def list_source_packages(session, tag, latest=True):
     return tag_info, results
 
 
-def list_update_source_packages(session, to_tag, from_tag=None, latest=True):
+def list_update_source_packages(session, to_tag,
+                                from_tags=None, latest=True):
     """
-    List source packages that have been updated from from_tag to to_tag.
-
-    If from_tag is provided, returns packages where the NVR in to_tag
-    is different from the NVR in from_tag.
+    List source packages that have been updated from one or more
+    from_tags to to_tag.
 
     Returns a dict mapping package name to its info:
         - nvr: name-version-release string in to_tag
         - version: package version in to_tag
         - release: package release in to_tag
-        - base_nvr: name-version-release string in from_tag (if provided)
-        - base_version: package version in from_tag
-        - base_release: package release in from_tag
+        - base_version: matching info from base tag or None
     """
     to_tag_info, to_packages = list_source_packages(session, to_tag)
 
     base_packages = {}
-    if from_tag:
-        _, base_packages = list_source_packages(session, from_tag)
+    if from_tags:
+        for from_tag in from_tags:
+            _, from_packages = list_source_packages(session, from_tag)
+            base_packages[from_tag] = from_packages
 
     results = {}
     for name, info in to_packages.items():
         to_nvr = info["nvr"]
-        if from_tag:
-            base_info = base_packages.get(name, {})
-            base_nvr = base_info.get("nvr")
-            if base_nvr and base_nvr != to_nvr:
-                results[name] = {
-                    "nvr": to_nvr,
-                    "version": info["version"],
-                    "release": info["release"],
-                    "base_nvr": base_nvr,
-                    "base_version": base_info.get("version"),
-                    "base_release": base_info.get("release"),
-                }
-        else:
+        if not from_tags:
             results[name] = {
                 "nvr": to_nvr,
                 "version": info["version"],
-                "release": info["release"]
+                "release": info["release"],
+                "base_version": None,
+            }
+        else:
+            base_version = None
+            for from_tag in from_tags:
+                from_pkgs = base_packages[from_tag]
+                if name in from_pkgs:
+                    base_info = from_pkgs[name]
+                    base_nvr = base_info.get("nvr")
+                    if base_nvr and base_nvr != to_nvr:
+                        base_version = base_info
+                        break
+
+            results[name] = {
+                "nvr": to_nvr,
+                "version": info["version"],
+                "release": info["release"],
+                "base_version": base_version,
             }
 
     return to_tag_info, results
@@ -138,7 +146,7 @@ def do_list(session, opts):
 
 def do_list_update(session, opts):
     tag_info, packages = list_update_source_packages(
-        session, opts.tag, from_tag=opts.base_tag
+        session, opts.tag, from_tags=opts.base_tags
     )
 
     if not packages:
@@ -146,15 +154,20 @@ def do_list_update(session, opts):
         sys.exit(0)
 
     lines = []
-    lines.append("Updated packages from"
-                 f"{opts.base_tag or 'any tag'} to {tag_info['name']}")
+    base_tags_str = ', '.join(opts.base_tags) if opts.base_tags else 'any tag'
+    lines.append(f"Updated packages from {base_tags_str}"
+                 f" to {tag_info['name']}")
     lines.append(f"Total updated source packages: {len(packages)}")
     lines.append("-" * 60)
 
     for name, info in sorted(packages.items()):
-        old_vr = f"{info.get('base_version')}-{info.get('base_release')}"
         new_vr = f"{info['version']}-{info['release']}"
-        lines.append(f"{name}: {old_vr} -> {new_vr}")
+        base_version = info.get("base_version")
+        if base_version:
+            old_vr = f"{base_version['version']}-{base_version['release']}"
+            lines.append(f"{name}: {old_vr} -> {new_vr}")
+        else:
+            lines.append(f"{name}: UNKNOWN -> {new_vr}")
 
     output_text = "\n".join(lines) + "\n"
 
@@ -182,9 +195,8 @@ def main():
     list_parser = subparsers.add_parser(
         "list",
         help="List all source packages from a tag")
-    list_parser.add_argument(
-        "tag",
-        help="The Koji tag to query (e.g., c9s, f40, epel9)")
+    list_parser.add_argument("tag",
+                             help="The Koji tag to query")
 
     # list-update command
     list_update_parser = subparsers.add_parser(
@@ -192,8 +204,9 @@ def main():
         help="List updated source packages between tags")
     list_update_parser.add_argument("tag", help="The target Koji tag")
     list_update_parser.add_argument(
-        "base_tag",
-        help="The source Koji tag to compare against")
+        "base_tags",
+        nargs="+",
+        help="The source Koji tags to compare against")
 
     global opts
     opts = parser.parse_args()

--- a/scripts/koji/koji-helper.py
+++ b/scripts/koji/koji-helper.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Philippe Coval <philippe.coval@vates.tech>
+#
+# SPDX-License-Identifier: MIT
+
+"""
+List all source packages from a Koji tag.
+
+Usage:
+    uv run list_source_packages.py <tag> [OPTIONS]
+
+Examples:
+    uv run list_source_packages.py c9s
+    uv run list_source_packages.py f40 --latest
+    uv run list_source_packages.py epel9 --output packages.txt
+"""
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "koji",
+# ]
+# ///
+
+import argparse
+import pdb
+import sys
+
+import koji
+
+
+def get_session(opts):
+    """Create and return a Koji client session."""
+    if opts.no_verify_ssl:
+        # Disable SSL verification warnings
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    session = koji.ClientSession(
+        opts.server,
+        opts={"no_ssl_verify": opts.no_verify_ssl},
+    )
+    return session
+
+
+def list_source_packages(session, tag, latest=False):
+    """
+    List all source packages in the given tag.
+
+    Returns a dict mapping package name to its info:
+        - nvr: name-version-release string
+    """
+    # Get the tag info
+    tag_info = session.getTag(tag, strict=True)
+
+    # Get all source builds in the tag
+    builds = session.listTagged(tag, latest=latest)
+
+    results = {}
+    for build in builds:
+        name = build["package_name"]
+        if name not in results:
+            results[name] = {
+                "nvr": build["nvr"]
+            }
+
+    return tag_info, results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="List all source packages from a Koji tag."
+    )
+    parser.add_argument(
+        "tag",
+        help="The Koji tag to query (e.g., c9s, f40, epel9)",
+    )
+    parser.add_argument(
+        "--server",
+        default="https://kojihub.xcp-ng.org",
+        help="Koji hub server URL (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--web-url",
+        default="https://koji.xcp-ng.org/",
+        help="Koji web UI URL (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--latest",
+        action="store_true",
+        help="Only show the latest build per package",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Output file path (default: stdout)",
+    )
+    parser.add_argument(
+        "--pdb",
+        action="store_true",
+        help="Drop into pdb on error",
+    )
+    parser.add_argument(
+        "--no-verify-ssl",
+        action="store_true",
+        help="Ignore SSL certificate verification errors",
+    )
+
+    global opts
+    opts = parser.parse_args()
+    session = get_session(opts)
+
+    try:
+        tag_info, packages = list_source_packages(
+            session, opts.tag, latest=opts.latest
+        )
+    except Exception as e:
+        if opts.pdb:
+            print(f"Error: {e}", file=sys.stderr)
+            pdb.post_mortem()
+        else:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if not packages:
+        print(f"No source packages found in tag '{opts.tag}'.", file=sys.stderr)
+        sys.exit(0)
+
+    # Format output
+    lines = []
+    lines.append(f"Tag: {tag_info['name']}")
+    lines.append(f"Total source packages: {len(packages)}")
+    lines.append("-" * 60)
+
+    for name, info in sorted(packages.items()):
+        lines.append(f"{info['nvr']}")
+
+    output_text = "\n".join(lines) + "\n"
+
+    if opts.output:
+        with open(opts.output, "w") as f:
+            f.write(output_text)
+        print(f"Output written to {opts.output}")
+    else:
+        print(output_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/koji/koji-helper.py
+++ b/scripts/koji/koji-helper.py
@@ -14,7 +14,7 @@ Usage:
 Examples:
     uv run koji-helper.py list v8.3-ci
     uv run koji-helper.py list-update v8.3-ci v8.3-updates
-    uv run koji-helper.py --no-verify-ssl list-update v8.3-ci \
+    uv run koji-helper.py list-update v8.3-ci \
       v8.3-testing v8.3-candidates v8.3-updates v8.3-base
 
 
@@ -48,10 +48,10 @@ Packages = dict[str, PackageInfo]
 
 def get_session(args: argparse.Namespace) -> koji.ClientSession:
     """Create and return a Koji client session."""
-    session = koji.ClientSession(
-        args.server,
-        opts={"no_ssl_verify": args.no_verify_ssl},
-    )
+    # Open a koji session
+    config = koji.read_config("koji")
+    session = koji.ClientSession(args.server, config)
+    session.ssl_login(config['cert'], None, config['serverca'])
     return session
 
 
@@ -202,12 +202,6 @@ def main() -> None:
         default="https://kojihub.xcp-ng.org",
         help="Koji hub server URL (default: %(default)s)",
     )
-    parser.add_argument(
-        "--no-verify-ssl",
-        action="store_true",
-        help="Ignore SSL certificate verification errors",
-    )
-
     subparsers = parser.add_subparsers(dest="command")
 
     # list command
@@ -233,15 +227,10 @@ def main() -> None:
 
     session = get_session(args)
 
-    try:
-        if args.command == "list":
-            do_list(session, args)
-        elif args.command == "list-update":
-            do_list_update(session, args)
-    except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
-
+    if args.command == "list":
+        do_list(session, args)
+    elif args.command == "list-update":
+        do_list_update(session, args)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This script is used to generated versions updates:

    uv run scripts/koji/koji-helper.py \
       list-update v8.3-ci \
       v8.3-testing v8.3-candidates v8.3-updates v8.3-base \
        | sed -e 's|\([^:]*\)\(.*\)|* `\1`\2|g' -e 's|UNKNOWN -> ||g'

It produces this kind of output (sed format to markdown):

   * `amd-microcode`: 20251203-1.1.xcpng8.3 -> 20260519-1.1.xcpng8.3
   * `perl-Archive-Tar`: 1.92-3.el7

